### PR TITLE
change card member writer

### DIFF
--- a/sources/plugins/carddav/carddav_backend.php
+++ b/sources/plugins/carddav/carddav_backend.php
@@ -1738,7 +1738,17 @@ EOF
 		$contact = self::get_dbrecord($cid,'cuid');
 		if(!$contact) return false;
 
-		$vcf->{'X-ADDRESSBOOKSERVER-MEMBER'} = "urn:uuid:" . $contact['cuid'];
+		//$vcf->{'X-ADDRESSBOOKSERVER-MEMBER'} = "urn:uuid:" . $contact['cuid'];
+		$search_for = 'urn:uuid:' . $contact['cuid'];
+		$member_exist = false;
+		foreach ($vcf->{'X-ADDRESSBOOKSERVER-MEMBER'} as $member) {
+			if ($member == $search_for) {
+				$member_exist = true;
+				break;
+			}
+		}
+		if(!$member_exist)	
+			$vcf->add('X-ADDRESSBOOKSERVER-MEMBER',$search_for);
 	}
 
 	$vcfstr = $vcf->serialize();


### PR DESCRIPTION
There was a problem when group have more than one member. The group always keeps a member despite that there are several. Therefore, this is a patch. I send this pullrequest to you because the original developer of the plugin seems to have abandoned it.