### PR TITLE
Adding a check for MySQL init

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -19,6 +19,11 @@ db_user=roundcube
 
 # Initialize database and store mysql password for upgrade
 sudo yunohost app initdb $db_user -p $db_pwd -s $(readlink -e ../sources/SQL/mysql.initial.sql)
+if [ ! "$?" -eq 0 ]; then
+  echo 'A problem occured with MySQL!' 1>&2
+  echo '"sudo service mysql restart" might fix the problem.' 1>&2
+  exit 1
+fi
 sudo yunohost app setting roundcube mysqlpwd -v $db_pwd
 
 mysql -u $db_user -p$db_pwd $db_user < ../sources/plugins/automatic_addressbook/SQL/mysql.initial.sql


### PR DESCRIPTION
I had the following problem with MySQL, but the script went on!

    Executing script...
    + domain=nicola-spanti.info
    + path=/webmail
    + sudo yunohost app checkurl nicola-spanti.info/webmail -a roundcube
    + [[ ! 0 -eq 0 ]]
    ++ sed -n 's/\(.\{24\}\).*/\1/p'
    ++ tr -c -d A-Za-z0-9
    ++ dd if=/dev/urandom bs=1 count=200
    + deskey=wzXFHMNB9Ne00TgJSmYvbmM6
    ++ sed -n 's/\(.\{24\}\).*/\1/p'
    ++ tr -c -d A-Za-z0-9
    ++ dd if=/dev/urandom bs=1 count=200
    + db_pwd=1R9E3IEsqw5SURwl45YcGXMf
    + db_user=roundcube
    ++ readlink -e ../sources/SQL/mysql.initial.sql
    + sudo yunohost app initdb roundcube -p 1R9E3IEsqw5SURwl45YcGXMf -s /var/cache/yunohost/from_file/roundcube_ynh-e1935dfc311de2700ea2cb7ad74dcc1519dbae2f/sources/SQL/mysql.initial.sql
    ERROR 2002 (HY000): Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (2)
    Error: MySQL database creation failed
    + sudo yunohost app setting roundcube mysqlpwd -v 1R9E3IEsqw5SURwl45YcGXMf
    + mysql -u roundcube -p1R9E3IEsqw5SURwl45YcGXMf roundcube
    ERROR 2002 (HY000): Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (2)